### PR TITLE
Fix yesno regex

### DIFF
--- a/lib/scripts/pr.js
+++ b/lib/scripts/pr.js
@@ -168,10 +168,10 @@ module.exports = function(robot) {
     f = (number != null ? number.match(/^#/) : void 0) ? (number = number.substring(1), pr.confirmMerging) : number != null ? pr.confirmMergingIssueNo : pr.list;
     return f.apply(pr, [res, user, repo, number]);
   });
-  robot.hear(/y(?:es)?/i, function(res) {
+  robot.hear(/^y(?:es)?$/i, function(res) {
     return pr.merge(res);
   });
-  return robot.hear(/n(?:o)?/i, function(res) {
+  return robot.hear(/^n(?:o)?$/i, function(res) {
     return pr.cancel(res);
   });
 };

--- a/src/scripts/pr.coffee
+++ b/src/scripts/pr.coffee
@@ -124,8 +124,8 @@ module.exports = (robot) ->
       pr.list
     f.apply pr, [res, user, repo, number]
 
-  robot.hear /y(?:es)?/i, (res) ->
+  robot.hear /^y(?:es)?$/i, (res) ->
     pr.merge res
 
-  robot.hear /n(?:o)?/i, (res) ->
+  robot.hear /^n(?:o)?$/i, (res) ->
     pr.cancel res

--- a/test/scripts/pr.coffee
+++ b/test/scripts/pr.coffee
@@ -122,6 +122,28 @@ describe 'pr', ->
           assert callback.callCount is 1
           assert.deepEqual actualMatches, matches
 
+    describe 'invalid patterns', ->
+      beforeEach ->
+        @messages = [
+          '_yes'
+          'yes_'
+          '_yes_'
+          '_y'
+          'y_'
+          '_y_'
+          '_Y'
+          'Y_'
+          '_Y_'
+        ]
+
+      it 'should not match', ->
+        @messages.forEach (message) =>
+          callback = @sinon.spy()
+          @robot.listeners[1].callback = callback
+          sender = new User 'bouzuya', room: 'hitoridokusho'
+          @robot.adapter.receive new TextMessage(sender, message)
+          assert callback.callCount is 0
+
   describe 'listeners[2].regex', ->
     describe 'valid patterns', ->
       beforeEach ->
@@ -145,6 +167,28 @@ describe 'pr', ->
           actualMatches = callback.firstCall.args[0].match.map((i) -> i)
           assert callback.callCount is 1
           assert.deepEqual actualMatches, matches
+
+    describe 'invalid patterns', ->
+      beforeEach ->
+        @messages = [
+          '_no'
+          'no_'
+          '_no_'
+          '_n'
+          'n_'
+          '_n_'
+          '_N'
+          'N_'
+          '_N_'
+        ]
+
+      it 'should not match', ->
+        @messages.forEach (message) =>
+          callback = @sinon.spy()
+          @robot.listeners[1].callback = callback
+          sender = new User 'bouzuya', room: 'hitoridokusho'
+          @robot.adapter.receive new TextMessage(sender, message)
+          assert callback.callCount is 0
 
   describe 'listeners[0].callback (pr)', ->
     beforeEach ->

--- a/test/scripts/pr.coffee
+++ b/test/scripts/pr.coffee
@@ -51,80 +51,100 @@ describe 'pr', ->
       done()
     @robot.shutdown()
 
-  describe 'patterns', ->
-    [
-      [
-        message: 'hubot pr hitoridokusho/hibot'
-        matches: [
-          'hubot pr hitoridokusho/hibot'
-          'hitoridokusho'
-          'hibot'
-          undefined
+  describe 'listeners[0].regex', ->
+    describe 'valid patterns', ->
+      beforeEach ->
+        @tests = [
+          message: 'hubot pr hitoridokusho/hibot'
+          matches: [
+            'hubot pr hitoridokusho/hibot'
+            'hitoridokusho'
+            'hibot'
+            undefined
+          ]
+        ,
+          message: 'hubot pr hitoridokusho/hibot #1'
+          matches: [
+            'hubot pr hitoridokusho/hibot #1'
+            'hitoridokusho'
+            'hibot'
+            '#1'
+          ]
+        ,
+          message: 'hubot pr hibot'
+          matches: [
+            'hubot pr hibot'
+            undefined
+            'hibot'
+            undefined
+          ]
+        ,
+          message: 'hubot pr hibot #1'
+          matches: [
+            'hubot pr hibot #1'
+            undefined
+            'hibot'
+            '#1'
+          ]
         ]
-      ,
-        message: 'hubot pr hitoridokusho/hibot #1'
-        matches: [
-          'hubot pr hitoridokusho/hibot #1'
-          'hitoridokusho'
-          'hibot'
-          '1'
-        ]
-      ,
-        message: 'hubot pr hibot'
-        matches: [
-          'hubot pr hibot'
-          undefined
-          'hibot'
-          undefined
-        ]
-      ,
-        message: 'hubot pr hibot #1'
-        matches: [
-          'hubot pr hibot #1'
-          undefined
-          'hibot'
-          '1'
-        ]
-      ]
-    ,
-      [
-        message: 'yes'
-        matches: ['yes']
-      ,
-        message: 'y'
-        matches: ['y']
-      ,
-        message: 'Y'
-        matches: ['Y']
-      ]
-    ,
-      [
-        message: 'no'
-        matches: ['no']
-      ,
-        message: 'n'
-        matches: ['n']
-      ,
-        message: 'N'
-        matches: ['N']
-      ]
-    ].forEach (tests, index) ->
-      describe "listeners[#{index}].regex", ->
-        tests.forEach ({ message, matches }) ->
-          beforeEach ->
-            @index = index
-            @message = message
-            @matches = matches
 
-          describe 'receive ' + message, ->
-            it 'should match', ->
-              callback = @sinon.spy()
-              @robot.listeners[@index].callback = callback
-              sender = new User 'bouzuya', room: 'hitoridokusho'
-              @robot.adapter.receive new TextMessage(sender, @message)
-              actualMatches = callback.firstCall.args[0].match.map((i) -> i)
-              assert callback.callCount is 1
-              assert.deepEqual actualMatches, @matches
+      it 'should match', ->
+        @tests.forEach ({ message, matches }) =>
+          callback = @sinon.spy()
+          @robot.listeners[0].callback = callback
+          sender = new User 'bouzuya', room: 'hitoridokusho'
+          @robot.adapter.receive new TextMessage(sender, message)
+          actualMatches = callback.firstCall.args[0].match.map((i) -> i)
+          assert callback.callCount is 1
+          assert.deepEqual actualMatches, matches
+
+  describe 'listeners[1].regex', ->
+    describe 'valid patterns', ->
+      beforeEach ->
+        @tests = [
+          message: 'yes'
+          matches: ['yes']
+        ,
+          message: 'y'
+          matches: ['y']
+        ,
+          message: 'Y'
+          matches: ['Y']
+        ]
+
+      it 'should match', ->
+        @tests.forEach ({ message, matches }) =>
+          callback = @sinon.spy()
+          @robot.listeners[1].callback = callback
+          sender = new User 'bouzuya', room: 'hitoridokusho'
+          @robot.adapter.receive new TextMessage(sender, message)
+          actualMatches = callback.firstCall.args[0].match.map((i) -> i)
+          assert callback.callCount is 1
+          assert.deepEqual actualMatches, matches
+
+  describe 'listeners[2].regex', ->
+    describe 'valid patterns', ->
+      beforeEach ->
+        @tests = [
+          message: 'no'
+          matches: ['no']
+        ,
+          message: 'n'
+          matches: ['n']
+        ,
+          message: 'N'
+          matches: ['N']
+        ]
+
+      it 'should match', ->
+        @tests.forEach ({ message, matches }) =>
+          callback = @sinon.spy()
+          @robot.listeners[2].callback = callback
+          sender = new User 'bouzuya', room: 'hitoridokusho'
+          @robot.adapter.receive new TextMessage(sender, message)
+          actualMatches = callback.firstCall.args[0].match.map((i) -> i)
+          assert callback.callCount is 1
+          assert.deepEqual actualMatches, matches
 
   describe 'listeners[0].callback (pr)', ->
     beforeEach ->


### PR DESCRIPTION
`yes`, `no` の誤爆が発生することがあるのでパターンを厳密に修正。
ローカルだと `callback` のスペックがこけるが、当該の修正とは無関係なので見てみぬふりした。
